### PR TITLE
fix: sticky positioned element's boundary is too small

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -12,12 +12,13 @@
   <body class="%body_class%">
     <div id="root">%sveltekit.body%</div>
     <script>
-      const appHeight = () => {
+      const setupStyleVar = () => {
         const doc = document.documentElement;
+        doc.style.setProperty('--client-width', `${document.documentElement.clientWidth}px`);
         doc.style.setProperty('--app-height', `${window.innerHeight}px`);
       };
-      window.addEventListener('resize', appHeight);
-      appHeight();
+      window.addEventListener('resize', setupStyleVar);
+      setupStyleVar();
     </script>
   </body>
 </html>

--- a/src/components/organisms/layout/Footer.svelte
+++ b/src/components/organisms/layout/Footer.svelte
@@ -53,7 +53,7 @@
   .footer {
     position: sticky;
     left: 0;
-    width: 100%;
+    width: var(--client-width);
     padding: 24px 0;
     background-color: rgba(var(--color-darkblue), 0.2);
 

--- a/src/components/organisms/layout/Nav.svelte
+++ b/src/components/organisms/layout/Nav.svelte
@@ -47,7 +47,7 @@
     display: flex;
     gap: 16px;
     align-items: center;
-    width: 100%;
+    width: var(--client-width);
     height: var(--nav-height);
     padding: 0 24px;
     background-color: rgba(var(--color-darkblue), 0.5);
@@ -57,7 +57,7 @@
       position: absolute;
       top: 0;
       left: 0;
-      width: 100%;
+      width: var(--app-width);
       height: var(--nav-height);
       pointer-events: none;
     }

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -4,8 +4,6 @@
 @import 'markdown';
 
 :root {
-  width: fit-content;
-
   --color-yellow: 255, 231, 110;
   --color-red: 245, 79, 81;
   --color-blue: 77, 147, 252;
@@ -23,6 +21,7 @@
 
   --app-height: 100%;
 
+  width: fit-content;
   color-scheme: dark;
 }
 

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -4,6 +4,8 @@
 @import 'markdown';
 
 :root {
+  width: fit-content;
+
   --color-yellow: 255, 231, 110;
   --color-red: 245, 79, 81;
   --color-blue: 77, 147, 252;


### PR DESCRIPTION
# To-do
- [x] 주요 대상 브라우저에서 `document.documentElement.clientWidth`를 모두 지원하는지 확인
- [x] `document.documentElement.clientWidth`가 오버레이된 스크롤 바의 사이즈를 포함하는 지, 포함한다면 이를 어떻게 처리할 지 결정
- [x] `:root`의 `width: fit-content;`가 적절한 변경인지 확인
- [x] 코드 스타일 리뷰